### PR TITLE
If we console.log "started sync", we should log "completed sync" as w…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -311,6 +311,7 @@ export default class ReadwisePlugin extends Plugin {
     await this.acknowledgeSyncCompleted(buttonContext);
     this.handleSyncSuccess(buttonContext, "Synced!", exportID);
     this.notice("Readwise sync completed", true, 1, true);
+    console.log("Readwise Official plugin: completed sync");
     // @ts-ignore
     if (this.app.isMobile) {
       this.notice("If you don't see all of your readwise files reload obsidian app", true,);
@@ -426,7 +427,7 @@ export default class ReadwisePlugin extends Plugin {
       this.saveSettings();
       this.requestArchive();
     }
-    console.log("started sync");
+    console.log("Readwise Official plugin: started sync");
   }
 
   async onload() {


### PR DESCRIPTION
…ell.

Also added "Readwise Official plugin" to started sync message, as other log lines do that.

Suggestion: have a log function that does it for you so it's done uniformly everywhere.