### PR TITLE
bugfix: ensure 'delete & reimport' works in reading view mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,7 @@ import {
   ButtonComponent,
   DataAdapter,
   debounce,
-  Editor,
-  MarkdownView, Modal,
+  Modal,
   normalizePath,
   Notice,
   Plugin,
@@ -487,14 +486,14 @@ export default class ReadwisePlugin extends Plugin {
     this.addCommand({
       id: 'readwise-official-reimport-file',
       name: 'Delete and reimport this document',
-      editorCheckCallback: (checking: boolean, editor: Editor, view: MarkdownView) => {
-        const activeFilePath = view.file.path;
+      checkCallback: (checking: boolean) => {
+        const activeFilePath = this.app.workspace.getActiveFile().path;
         const isRWfile = activeFilePath in this.settings.booksIDsMap;
         if (checking) {
           return isRWfile;
         }
         if (this.settings.reimportShowConfirmation) {
-          const modal = new Modal(view.app);
+          const modal = new Modal(this.app);
           modal.contentEl.createEl(
             'p',
             {
@@ -516,12 +515,12 @@ export default class ReadwisePlugin extends Plugin {
             modal.close();
           });
           confirmBtn.onClickEvent(() => {
-            this.reimportFile(view.app.vault, activeFilePath);
+            this.reimportFile(this.app.vault, activeFilePath);
             modal.close();
           });
           modal.open();
         } else {
-          this.reimportFile(view.app.vault, activeFilePath);
+          this.reimportFile(this.app.vault, activeFilePath);
         }
       }
     });


### PR DESCRIPTION
Makes the `Delete and reimport` command work when in "reading" mode (pictured below)

![image](https://github.com/readwiseio/obsidian-readwise/assets/595711/8ee3e4a3-d2fd-4afc-aabb-6450c71e0f88)

Seeing as how readwise exports should generally be treated as read-only, i recently started using [another obsidian plugin](https://github.com/bwydoogh/obsidian-force-view-mode-of-note) to force the view mode of my readwise exports into the "reading" mode (that plugin calls it `obsidianUIMode: preview`) - which led me to discovering this quirk (:bug:) in the `obsidian-readwise` plugin: it only worked when in "editing" mode.

This PR fixes that by changing the callback to [`checkCallback`](https://docs.obsidian.md/Reference/TypeScript+API/Command/checkCallback) which is triggered regardless of the view mode instead of the original [`editorCheckCallback`](https://docs.obsidian.md/Reference/TypeScript+API/Command/editorCheckCallback) which "is only triggered when the user is in an editor".

I have tested this change in a test vault - it works :heavy_check_mark:

Here's proof - notice the icon i've circled, which indicates that this is in the "reading" mode (it is a book icon when in editing mode) :arrow_heading_down: 
![image](https://github.com/readwiseio/obsidian-readwise/assets/595711/175465ad-134c-4bd0-8723-10f6742bf1ee)
