### PR TITLE
fix: improve "delete and reimport" modal styles

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -495,18 +495,20 @@ export default class ReadwisePlugin extends Plugin {
         }
         if (this.settings.reimportShowConfirmation) {
           const modal = new Modal(this.app);
+          modal.titleEl.setText("Delete and reimport this document?");
           modal.contentEl.createEl(
             'p',
             {
-              'text': 'Warning: Proceeding will delete this file entirely (including any changes you made) ' +
-                'and then reimport a new copy of your highlights from Readwise.'
+              text: 'Warning: Proceeding will delete this file entirely (including any changes you made) ' +
+                'and then reimport a new copy of your highlights from Readwise.',
+              cls: 'rw-modal-warning-text',
             });
           const buttonsContainer = modal.contentEl.createEl('div', {"cls": "rw-modal-btns"});
           const cancelBtn = buttonsContainer.createEl("button", {"text": "Cancel"});
           const confirmBtn = buttonsContainer.createEl("button", {"text": "Proceed", 'cls': 'mod-warning'});
           const showConfContainer = modal.contentEl.createEl('div', {'cls': 'rw-modal-confirmation'});
           showConfContainer.createEl("label", {"attr": {"for": "rw-ask-nl"}, "text": "Don't ask me in the future"});
-          const showConf = showConfContainer.createEl("input", {"type": "checkbox", "attr": {"name": "rw-ask-nl"}});
+          const showConf = showConfContainer.createEl("input", {"type": "checkbox", "attr": {"name": "rw-ask-nl", "id": "rw-ask-nl"}});
           showConf.addEventListener('change', (ev) => {
             // @ts-ignore
             this.settings.reimportShowConfirmation = !ev.target.checked;

--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@
 }
 
 .rw-info-container {
-    margin-right: 10px;
+    margin-inline-end: 10px;
 }
 
 .rw-info {
@@ -41,11 +41,18 @@ img[alt=rw-book-cover] {
 .rw-modal-btns {
     display: flex;
     justify-content: flex-end;
+    gap: 0.5rem;
 }
 
 .rw-modal-confirmation {
-    margin-top: 1em;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    justify-content: flex-end;
+    margin-block-start: 1em;
     font-size: smaller;
-    text-align: right;
-    padding-right: 12px;
+}
+
+.rw-modal-warning-text {
+    margin-block-start: 0;
 }


### PR DESCRIPTION
A few small changes.

- added gap between the buttons
- added title to modal
- aligned the label/checkbox
- made the label clickable (checks its corresponding checkbox)

Before :x:

![image](https://github.com/readwiseio/obsidian-readwise/assets/595711/13beeab8-7621-4380-a3d0-757c71530806)

After :sparkles: 

![image](https://github.com/readwiseio/obsidian-readwise/assets/595711/4e911bd6-8d9d-4ba1-8a20-60bce683ec84)
