### PR TITLE
refactor: improve sync reliability

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -156,7 +156,7 @@ export default class ReadwisePlugin extends Plugin {
       }
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in getExportStatus: ", e);
-      this.handleSyncError(buttonContext, this.getErrorMessageFromResponse(e));
+      this.handleSyncError(buttonContext, "Sync failed");
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -312,8 +312,7 @@ export default class ReadwisePlugin extends Plugin {
           console.log(`Readwise Official plugin: error writing ${processedFileName}:`, e);
           this.notice(`Readwise: error while writing ${processedFileName}: ${e}`, true, 4, true);
           if (bookID) {
-            this.settings.booksToRefresh.push(bookID);
-            await this.saveSettings();
+            await this.addBookToRefresh(bookID);
           }
           // communicate with readwise?
         }
@@ -421,7 +420,8 @@ export default class ReadwisePlugin extends Plugin {
         return;
       } else {
         console.log(`Readwise Official plugin: saving book id ${bookIds} to refresh later`);
-        this.settings.booksToRefresh = [...this.settings.booksToRefresh, ...bookIds]
+        const deduplicatedBookIds = new Set([...this.settings.booksToRefresh, ...bookIds]);
+        this.settings.booksToRefresh = Array.from(deduplicatedBookIds);
         await this.saveSettings();
         return;
       }
@@ -433,6 +433,7 @@ export default class ReadwisePlugin extends Plugin {
   async addBookToRefresh(bookId: string) {
     let booksToRefresh = this.settings.booksToRefresh;
     booksToRefresh.push(bookId);
+    console.log(`Readwise Official plugin: added book id ${bookId} to refresh later`);
     this.settings.booksToRefresh = booksToRefresh;
     await this.saveSettings();
   }
@@ -440,6 +441,7 @@ export default class ReadwisePlugin extends Plugin {
   async removeBooksFromRefresh(bookIds: Array<string> = []) {
     if (!bookIds.length) return;
 
+    console.log(`Readwise Official plugin: removing book ids ${bookIds.join(', ')} from refresh list`);
     this.settings.booksToRefresh = this.settings.booksToRefresh.filter(n => !bookIds.includes(n));
     await this.saveSettings();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -66,19 +66,20 @@ interface ReadwisePluginSettings {
 }
 
 // define our initial settings
+// quoted keys for easy copying to data.json during development
 const DEFAULT_SETTINGS: ReadwisePluginSettings = {
-  token: "",
-  readwiseDir: "Readwise",
-  frequency: "0", // manual by default
-  triggerOnLoad: true,
-  isSyncing: false,
-  lastSyncFailed: false,
-  lastSavedStatusID: 0,
-  currentSyncStatusID: 0,
-  refreshBooks: false,
-  booksToRefresh: [],
-  booksIDsMap: {},
-  reimportShowConfirmation: true,
+  "token": "",
+  "readwiseDir": "Readwise",
+  "frequency": "0",
+  "triggerOnLoad": true,
+  "isSyncing": false,
+  "lastSyncFailed": false,
+  "lastSavedStatusID": 0,
+  "currentSyncStatusID": 0,
+  "refreshBooks": false,
+  "booksToRefresh": [],
+  "booksIDsMap": {},
+  "reimportShowConfirmation": true
 };
 
 export default class ReadwisePlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -387,7 +387,8 @@ export default class ReadwisePlugin extends Plugin {
 
     // add potentially-missing books to booksToRefresh (TODO - prob a lil inefficient? 🤷)
     const knownFilesPaths = Object.keys(this.settings.booksIDsMap);
-    if (this.settings.refreshBooks) {
+    const shouldGetMissingBooks = this.settings.refreshBooks && !bookIds?.length;
+    if (shouldGetMissingBooks) {
       for (const knownFilePath of knownFilesPaths) {
         const file = this.app.vault.getAbstractFileByPath(knownFilePath);
         if (!file) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -490,8 +490,8 @@ export default class ReadwisePlugin extends Plugin {
       id: 'readwise-official-reimport-file',
       name: 'Delete and reimport this document',
       checkCallback: (checking: boolean) => {
-        const activeFilePath = this.app.workspace.getActiveFile().path;
-        const isRWfile = activeFilePath in this.settings.booksIDsMap;
+        const activeFilePath = this.app.workspace.getActiveFile()?.path;
+        const isRWfile = activeFilePath && activeFilePath in this.settings.booksIDsMap;
         if (checking) {
           return isRWfile;
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -144,15 +144,15 @@ export default class ReadwisePlugin extends Plugin {
           // then keep polling
           await this.getExportStatus(statusID, buttonContext);
         } else if (SUCCESS_STATUSES.includes(data.taskStatus)) {
-          console.log('New highlights found, downloading archive');
           await this.downloadArchive(statusID, buttonContext);
         } else {
-          console.log("Readwise Official plugin: bad response in getExportStatus: ", response);
-          this.handleSyncError(buttonContext, this.getErrorMessageFromResponse(response));
+          console.log("Readwise Official plugin: unknown status in getExportStatus: ", data);
+          this.handleSyncError(buttonContext, "Sync failed");
           return;
         }
       } else {
-        this.handleSyncError(buttonContext, "Sync failed");
+        console.log("Readwise Official plugin: bad response in getExportStatus: ", response);
+        this.handleSyncError(buttonContext, this.getErrorMessageFromResponse(response));
       }
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in getExportStatus: ", e);

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,10 @@ const DEFAULT_SETTINGS: ReadwisePluginSettings = {
   "reimportShowConfirmation": true
 };
 
-/** The name of the Readwise Sync history file, without the extension. */
-const READWISE_SYNC_FILENAME = "Readwise Sync" as const;
+/** The name of the Readwise Sync history file, without the extension.
+ * This is described as "Sync notification" in the Obsidian export settings
+ * on the Readwise website. */
+const READWISE_SYNC_FILENAME = "Readwise Syncs" as const;
 
 export default class ReadwisePlugin extends Plugin {
   settings: ReadwisePluginSettings;

--- a/src/main.ts
+++ b/src/main.ts
@@ -479,16 +479,6 @@ export default class ReadwisePlugin extends Plugin {
       );
     }
 
-    this.app.vault.on("delete", async (file) => {
-      // user has "Resync deleted files" enabled
-      if (this.settings.refreshBooks) {
-        const bookId = this.settings.booksIDsMap[file.path];
-        if (!bookId) return;
-
-        // queue the book for refresh
-        await this.addBookToRefresh(bookId);
-      }
-    });
     this.app.vault.on("rename", async (file, oldPath) => {
       const bookId = this.settings.booksIDsMap[oldPath];
       if (!bookId) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -390,7 +390,7 @@ export default class ReadwisePlugin extends Plugin {
       }
     }
 
-    const hasNeverSynced = !Object.keys(this.settings.booksIDsMap).length;
+    const hasNeverSynced = !knownFilesPaths.length;
     if (hasNeverSynced) {
       this.notice("Preparing initial Readwise sync...", true);
       await this.startSync();

--- a/src/main.ts
+++ b/src/main.ts
@@ -359,7 +359,6 @@ export default class ReadwisePlugin extends Plugin {
           }
           await this.fs.write(originalName, contentToSave);
           await this.removeBooksFromRefresh([bookID]);
-          await this.saveSettings();
         } catch (e) {
           console.log(`Readwise Official plugin: error writing ${processedFileName}:`, e);
           this.notice(`Readwise: error while writing ${processedFileName}: ${e}`, true, 4, true);

--- a/src/main.ts
+++ b/src/main.ts
@@ -358,6 +358,18 @@ export default class ReadwisePlugin extends Plugin {
   async refreshBookExport(bookIds?: Array<string>) {
     const targetBookIds = bookIds || this.settings.booksToRefresh;
 
+    // add potentially-missing books to booksToRefresh (TODO - prob a lil inefficient? 🤷)
+    const knownFilesPaths = Object.keys(this.settings.booksIDsMap);
+    if (this.settings.refreshBooks) {
+      for (const knownFilePath of knownFilesPaths) {
+        const file = this.app.vault.getAbstractFileByPath(knownFilePath);
+        if (!file) {
+          const bookId = this.settings.booksIDsMap[knownFilePath];
+          targetBookIds.push(bookId);
+        }
+      }
+    }
+
     if (!targetBookIds.length) {
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import {
   Vault
 } from 'obsidian';
 import * as zip from "@zip.js/zip.js";
-import {StatusBar} from "./status";
+import { StatusBar } from "./status";
 
 
 // the process.env variable will be replaced by its target value in the output main.js file
@@ -258,7 +258,7 @@ export default class ReadwisePlugin extends Plugin {
     let response, blob;
     try {
       response = await fetch(
-        artifactURL, {headers: this.getAuthHeaders()}
+        artifactURL, { headers: this.getAuthHeaders() }
       );
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in downloadArchive: ", e);
@@ -336,7 +336,7 @@ export default class ReadwisePlugin extends Plugin {
       response = await fetch(
         `${baseURL}/api/obsidian/sync_ack`,
         {
-          headers: {...this.getAuthHeaders(), 'Content-Type': 'application/json'},
+          headers: { ...this.getAuthHeaders(), 'Content-Type': 'application/json' },
           method: "POST",
         });
     } catch (e) {
@@ -403,15 +403,15 @@ export default class ReadwisePlugin extends Plugin {
       return;
     }
 
-    console.log('Readwise Official plugin: refreshing books', { targetBookIds  });
+    console.log('Readwise Official plugin: refreshing books', { targetBookIds });
 
     try {
       const response = await fetch(
         `${baseURL}/api/refresh_book_export`,
         {
-          headers: {...this.getAuthHeaders(), 'Content-Type': 'application/json'},
+          headers: { ...this.getAuthHeaders(), 'Content-Type': 'application/json' },
           method: "POST",
-          body: JSON.stringify({exportTarget: 'obsidian', books: targetBookIds})
+          body: JSON.stringify({ exportTarget: 'obsidian', books: targetBookIds })
         }
       );
 
@@ -519,12 +519,12 @@ export default class ReadwisePlugin extends Plugin {
                 'and then reimport a new copy of your highlights from Readwise.',
               cls: 'rw-modal-warning-text',
             });
-          const buttonsContainer = modal.contentEl.createEl('div', {"cls": "rw-modal-btns"});
-          const cancelBtn = buttonsContainer.createEl("button", {"text": "Cancel"});
-          const confirmBtn = buttonsContainer.createEl("button", {"text": "Proceed", 'cls': 'mod-warning'});
-          const showConfContainer = modal.contentEl.createEl('div', {'cls': 'rw-modal-confirmation'});
-          showConfContainer.createEl("label", {"attr": {"for": "rw-ask-nl"}, "text": "Don't ask me in the future"});
-          const showConf = showConfContainer.createEl("input", {"type": "checkbox", "attr": {"name": "rw-ask-nl", "id": "rw-ask-nl"}});
+          const buttonsContainer = modal.contentEl.createEl('div', { "cls": "rw-modal-btns" });
+          const cancelBtn = buttonsContainer.createEl("button", { "text": "Cancel" });
+          const confirmBtn = buttonsContainer.createEl("button", { "text": "Proceed", 'cls': 'mod-warning' });
+          const showConfContainer = modal.contentEl.createEl('div', { 'cls': 'rw-modal-confirmation' });
+          showConfContainer.createEl("label", { "attr": { "for": "rw-ask-nl" }, "text": "Don't ask me in the future" });
+          const showConf = showConfContainer.createEl("input", { "type": "checkbox", "attr": { "name": "rw-ask-nl", "id": "rw-ask-nl" } });
           showConf.addEventListener('change', async (ev) => {
             // @ts-expect-error - target.checked is not typed (TODO add type narrowing)
             this.settings.reimportShowConfirmation = !ev.target.checked;
@@ -660,13 +660,13 @@ class ReadwiseSettingTab extends PluginSettingTab {
 
 
   display(): void {
-    let {containerEl} = this;
+    let { containerEl } = this;
 
     containerEl.empty();
-    containerEl.createEl('h1', {text: 'Readwise Official'});
-    containerEl.createEl('p', {text: 'Created by '}).createEl('a', {text: 'Readwise', href: 'https://readwise.io'});
+    containerEl.createEl('h1', { text: 'Readwise Official' });
+    containerEl.createEl('p', { text: 'Created by ' }).createEl('a', { text: 'Readwise', href: 'https://readwise.io' });
     containerEl.getElementsByTagName('p')[0].appendText(' 📚');
-    containerEl.createEl('h2', {text: 'Settings'});
+    containerEl.createEl('h2', { text: 'Settings' });
 
     if (this.plugin.settings.token) {
       new Setting(containerEl)
@@ -689,7 +689,7 @@ class ReadwiseSettingTab extends PluginSettingTab {
               }
             });
         });
-      let el = containerEl.createEl("div", {cls: "rw-info-container"});
+      let el = containerEl.createEl("div", { cls: "rw-info-container" });
       containerEl.find(".rw-setting-sync > .setting-item-control ").prepend(el);
 
       new Setting(containerEl)
@@ -722,7 +722,7 @@ class ReadwiseSettingTab extends PluginSettingTab {
           dropdown.addOption((12 * 60).toString(), "Every 12 hours");
           dropdown.addOption((24 * 60).toString(), "Every 24 hours");
           dropdown.addOption((7 * 24 * 60).toString(), "Every week");
-        
+
           // select the currently-saved option
           dropdown.setValue(this.plugin.settings.frequency);
 
@@ -739,26 +739,26 @@ class ReadwiseSettingTab extends PluginSettingTab {
         .setName("Sync automatically when Obsidian opens")
         .setDesc("If enabled, Readwise will automatically resync with Obsidian each time you open the app")
         .addToggle((toggle) => {
-            toggle.setValue(this.plugin.settings.triggerOnLoad);
-            toggle.onChange(async (val) => {
-              this.plugin.settings.triggerOnLoad = val;
-              await this.plugin.saveSettings();
-            });
-          }
+          toggle.setValue(this.plugin.settings.triggerOnLoad);
+          toggle.onChange(async (val) => {
+            this.plugin.settings.triggerOnLoad = val;
+            await this.plugin.saveSettings();
+          });
+        }
         );
       new Setting(containerEl)
         .setName("Resync deleted files")
         .setDesc("If enabled, you can refresh individual items by deleting the file in Obsidian and initiating a resync")
         .addToggle((toggle) => {
-            toggle.setValue(this.plugin.settings.refreshBooks);
-            toggle.onChange(async (val) => {
-              this.plugin.settings.refreshBooks = val;
-              await this.plugin.saveSettings();
-              if (val) {
-                await this.plugin.refreshBookExport();
-              }
-            });
-          }
+          toggle.setValue(this.plugin.settings.refreshBooks);
+          toggle.onChange(async (val) => {
+            this.plugin.settings.refreshBooks = val;
+            await this.plugin.saveSettings();
+            if (val) {
+              await this.plugin.refreshBookExport();
+            }
+          });
+        }
         );
 
       if (this.plugin.settings.lastSyncFailed) {
@@ -780,7 +780,7 @@ class ReadwiseSettingTab extends PluginSettingTab {
             }
           });
         });
-      let el = containerEl.createEl("div", {cls: "rw-info-container"});
+      let el = containerEl.createEl("div", { cls: "rw-info-container" });
       containerEl.find(".rw-setting-connect > .setting-item-control ").prepend(el);
     }
     const help = containerEl.createEl('p',);

--- a/src/main.ts
+++ b/src/main.ts
@@ -360,28 +360,28 @@ export default class ReadwisePlugin extends Plugin {
       return;
     }
     try {
-      fetch(
+      const response = await fetch(
         `${baseURL}/api/refresh_book_export`,
         {
           headers: {...this.getAuthHeaders(), 'Content-Type': 'application/json'},
           method: "POST",
           body: JSON.stringify({exportTarget: 'obsidian', books: bookIds})
         }
-      ).then(response => {
-        if (response && response.ok) {
-          let booksToRefresh = this.settings.booksToRefresh;
-          this.settings.booksToRefresh = booksToRefresh.filter(n => !bookIds.includes(n));
-          this.saveSettings();
-          return;
-        } else {
-          console.log(`Readwise Official plugin: saving book id ${bookIds} to refresh later`);
-          let booksToRefresh = this.settings.booksToRefresh;
-          booksToRefresh.concat(bookIds);
-          this.settings.booksToRefresh = booksToRefresh;
-          this.saveSettings();
-          return;
-        }
-      });
+      );
+
+      if (response && response.ok) {
+        let booksToRefresh = this.settings.booksToRefresh;
+        this.settings.booksToRefresh = booksToRefresh.filter(n => !bookIds.includes(n));
+        await this.saveSettings();
+        return;
+      } else {
+        console.log(`Readwise Official plugin: saving book id ${bookIds} to refresh later`);
+        let booksToRefresh = this.settings.booksToRefresh;
+        booksToRefresh.concat(bookIds);
+        this.settings.booksToRefresh = booksToRefresh;
+        await this.saveSettings();
+        return;
+      }
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in refreshBookExport: ", e);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -395,27 +395,13 @@ export default class ReadwisePlugin extends Plugin {
   }
 
   async reimportFile(vault: Vault, fileName: string) {
-    const bookId = this.settings.booksIDsMap[fileName];
     try {
-      this.notice("Reimporting file...", true);
-      const response = await fetch(
-        `${baseURL}/api/refresh_book_export`,
-        {
-          headers: {...this.getAuthHeaders(), 'Content-Type': 'application/json'},
-          method: "POST",
-          body: JSON.stringify({exportTarget: 'obsidian', books: [bookId]})
-        }
-      );
+      this.notice("Deleting and reimporting file...", true);
 
-      if (response && response.ok) {
-        let booksToRefresh = this.settings.booksToRefresh;
-        this.settings.booksToRefresh = booksToRefresh.filter(n => ![bookId].includes(n));
-        await this.saveSettings();
-        await vault.delete(vault.getAbstractFileByPath(fileName));
-        await this.startSync();
-      } else {
-        this.notice("Failed to reimport. Please try again", true);
-      }
+      // the .on("delete") listener will add this file to booksToRefresh
+      await vault.delete(vault.getAbstractFileByPath(fileName));
+      // sync will grab missing booksToRefresh
+      await this.startSync();
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in Reimport current file: ", e);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -480,10 +480,11 @@ export default class ReadwisePlugin extends Plugin {
     }
 
     this.app.vault.on("delete", async (file) => {
-      const bookId = this.settings.booksIDsMap[file.path];
-
       // user has "Resync deleted files" enabled
       if (this.settings.refreshBooks) {
+        const bookId = this.settings.booksIDsMap[file.path];
+        if (!bookId) return;
+
         // queue the book for refresh
         await this.addBookToRefresh(bookId);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,7 @@ export default class ReadwisePlugin extends Plugin {
       }
     } catch (e) {
       console.log("Readwise Official plugin: fetch failed in getExportStatus: ", e);
+      this.handleSyncError(buttonContext, this.getErrorMessageFromResponse(e));
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -364,6 +364,7 @@ export default class ReadwisePlugin extends Plugin {
           console.log(`Readwise Official plugin: error writing ${processedFileName}:`, e);
           this.notice(`Readwise: error while writing ${processedFileName}: ${e}`, true, 4, true);
           if (bookID) {
+            // handles case where user doesn't have `settings.refreshBooks` enabled
             await this.addBookToRefresh(bookID);
           }
           // communicate with readwise?

--- a/src/main.ts
+++ b/src/main.ts
@@ -430,6 +430,8 @@ export default class ReadwisePlugin extends Plugin {
   }
 
   async onload() {
+    await this.loadSettings();
+
     // @ts-ignore
     if (!this.app.isMobile) {
       this.statusBar = new StatusBar(this.addStatusBarItem());

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,16 +35,33 @@ interface ExportStatusResponse {
 
 interface ReadwisePluginSettings {
   token: string;
+
+  /** Folder to save highlights */
   readwiseDir: string;
+
+  /** Polling for pending export */
   isSyncing: boolean;
+
+  /** Frequency of automatic sync */
   frequency: string;
+
+  /** Automatically sync on load */
   triggerOnLoad: boolean;
+
   lastSyncFailed: boolean;
   lastSavedStatusID: number;
   currentSyncStatusID: number;
+
+  /** Should get any deleted books */
   refreshBooks: boolean,
+
+  /** Queue of books to refresh */
   booksToRefresh: Array<string>;
-  booksIDsMap: { [key: string]: string; };
+
+  /** Map of file path to book ID */
+  booksIDsMap: { [filePath: string]: string; };
+
+  /** User choice for confirming delete and reimport */
   reimportShowConfirmation: boolean;
 }
 
@@ -66,7 +83,7 @@ const DEFAULT_SETTINGS: ReadwisePluginSettings = {
 
 export default class ReadwisePlugin extends Plugin {
   settings: ReadwisePluginSettings;
-  fs: DataAdapter;
+  fs: dDataAdapter;
   vault: Vault;
   scheduleInterval: null | number = null;
   statusBar: StatusBar;

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ const DEFAULT_SETTINGS: ReadwisePluginSettings = {
 
 export default class ReadwisePlugin extends Plugin {
   settings: ReadwisePluginSettings;
-  fs: dDataAdapter;
+  fs: DataAdapter;
   vault: Vault;
   scheduleInterval: null | number = null;
   statusBar: StatusBar;


### PR DESCRIPTION
# related issues

- fixes #45
- may help #68
  - unclear what underlying cause of this issue is, though this PR removes code that removes items from `booksIDsMap` altogether - so i suspect it should help as that is now modified less
  - this issue is also caused by Obsidian Sync
- may help #14

# tl;dr

- substantially improve the ability to resync deleted items
- unify resync logic
- fix issues where the plugin thought there was nothing to sync
- reduces hacks/workarounds, and generally improve the codebase

# sync changes

> [!NOTE]  
> some name changes since i originally posted the notes below, see [this comment](https://github.com/readwiseio/obsidian-readwise/pull/67#discussion_r1739794857)
> - `refreshBookExport` has been renamed to `syncBookHighlights`
> - `startSync` has been folded into `requestArchive`
> - `requestArchive` has been renamed to `queueExport`
> - `downloadArchive` has been renamed to `downloadExport`

Primarily:

1. Make `refreshBookExport` async
    - There is no reason for it not to be, though that's largely because
      it is now debounced. (keep reading)
2. Remove `debounce` from refreshBookExport
    - I suspect this only ever existed because the 'delete' listener
      fires for *each* file that is deleted, which in turn was firing
      the `refreshBookExport` function a ton of times. (it isn't called
      in the 'delete' listener anymore - keep reading)
3. Defer `refreshBookExport` to sync events
    - aka don't call this when deleting files
    - ensure `refreshBookExport` called when syncing - both on
      scheduled and on-demand
4. Generally ensure *all* syncing happens via `refreshBookExport`
    - ensures that the various sync methods won't get tangled up very easily (eg writing to settings via various sync operations in tandem)

Additionally:
- async/await *most* `saveSettings` - i suspect this was causing issues where settings would get clobbered. either way, couldn't see a reason not to do this in *most* cases.

All of these combined should ensure a much more reliably sync operation.

Extensive testing instructions found at bottom of this post ⤵

# notes dump

clean plugin install happens

default `data.json` (aka `settings`):
```
{
  "token": "",
  "readwiseDir": "Readwise",
  "frequency": "0",
  "triggerOnLoad": true,
  "isSyncing": false,
  "lastSyncFailed": false,
  "lastSavedStatusID": 0,
  "currentSyncStatusID": 0,
  "refreshBooks": false,
  "booksToRefresh": [],
  "booksIDsMap": {},
  "reimportShowConfirmation": true
}
```

user clicks "connect"
- `getUserAuthToken()` → saves to `settings.token`
- web browser opens to `https://readwise.io/export/obsidian/preferences`
- obsidian plugin UI refreshes to show all options now that user is authenticated

note that sync frequency is manual/`0` at this point

user initiates initial/first sync — this can happen one of several ways:
1. click "initiate sync"
	- `refreshBookExport`
1. `Sync your data now` command
	- `refreshBookExport`
1. toggle on "resync deleted files"
	- `refreshBookExport`
1. reload workspace
	- `onload` → `refreshBookExport`
1. interval is triggered
	- `configureSchedule` → `refreshBookExport`

after the initial sync, `settings.lastSavedStatusID` and `settings.booksIDsMap` are populated

at this point, the user may also use the `Delete and reimport this document` command within a specific Readwise export — that also simply uses `refreshBookExport`

 notes about `refreshBookExport`
- **all** syncing goes through this. ==very important== because it ensures that the various sync methods won't get tangled up very easily (eg writing to settings via various sync operations in tandem)
- `refreshBookExport` will always trigger a `requestArchive` (either directly or via `startSync`), regardless of if it was provided specific books to refresh, so new highlights should always appear

notes about "resync deleted files" (aka `settings.refreshBooks`):
- if enabled OR disabled:
 	- the entry will remain in `booksIDsMap` so we have a copy of its book ID
	- book IDs will NOT be added to `booksToRefresh` as they are deleted (see `if enabled` for rationale)
- if enabled:
	- `refreshBookExport` will look for a difference in the filesystem vs what is in `booksIDsMap` — seemed like the only way to handle filesystem deletions (outside of Obsidian), unknown performance when there are many many readwise files. could be moved behind a toggle if it's particularly slow.

other notes:
- `auto` query string seems to indicate that the sync wasn't triggered by a user (eg interval sync)
- when `settings.readwiseDir` isn't there, the `requestArchive` will use the `parentPageDeleted` querystring (like `/api/obsidian/init?parentPageDeleted=true`) — there's no documentation on this, but i did test it and it does successfully sync the files in a clean install

## install for testing

you can download and build the plugin yourself, or use [BRAT](https://github.com/TfTHacker/obsidian42-brat) to install a pre-built beta:
1. disable the current Readwise plugin in your Obsidian
1. install [BRAT](https://github.com/TfTHacker/obsidian42-brat) via Obsidian community plugins and enable the BRAT plugin
1. within BRAT's plugin settings, click the "Add Beta plugin with frozen version" button
1. fill the fields in with the beta info 
  Repository: `https://github.com/tyler-dot-earth/dev-obsidian-readwise`
  Latest pre-built version: `refactor-improve-sync-reliability-beta-5`
  Should look a bit like this:
  ![Screenshot from 2024-07-06 10-48-27](https://github.com/readwiseio/obsidian-readwise/assets/595711/7c1b8784-dcef-402c-be25-36f36afa3731)
1. use the plugin like normal


## how to test thoroughly

> [!WARNING]  
> perform these in listed order

- [ ] confirm clean plugin install syncs notes as expected (this isn't automatic; you must click "initiate sync" or reload the workspace after authenticating)

- **enable `Resync deleted files`**
- delete a synced file
- use command palette to `Readwise Official: Sync your data now`
- [ ] confirm deleted file **is** re-synced

- delete a synced file
- open plugin settings and click `Initiate sync`
- [ ] confirm deleted file **is** re-synced

- open a synced file
- use command palette to `Readwise Official: Delete and reimport this document`
- [ ] confirm file is deleted and **is** re-synced

- delete synced file
- use command palette to `Reload app without saving` (or re-open Obsidian)
- [ ] confirm deleted file **is** re-synced

- **disable `Resync deleted files`**
- delete a synced file
- use command palette to `Readwise Official: Sync your data now`
- [ ] confirm file is **NOT** re-synced

- delete a synced file
- open plugin settings and click `Initiate sync`
- [ ] confirm file is **NOT** re-synced

- open a synced file
- use command palette to `Readwise Official: Delete and reimport this document`
- [ ] confirm file **is** re-synced

- delete synced file
- use command palette to `Reload app without saving` (or re-open Obsidian)
- [ ] confirm deleted file **is** re-synced

- delete synced file
- **enable `Resync deleted files`**
- [ ] confirm deleted file **is** re-synced

- and finally, for good measure:
- [ ] ensure adding new highlights continues to work as expected
- [ ] ensure syncing on interval continues to work as expected


# other changes

- a few random, small bugfixes and refactors. i'm happy to split into their own PR, but felt like more friction than it was worth for both me and reviewer(s).