### PR TITLE
:ambulance: Restore legacy file deletion, handle failed books, add comments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -373,6 +373,7 @@ export default class ReadwisePlugin extends Plugin {
           if (bookID) {
             // handles case where user doesn't have `settings.refreshBooks` enabled
             await this.addToFailedBooks(bookID);
+            await this.saveSettings();
             return;
           }
           // communicate with readwise?
@@ -500,7 +501,9 @@ export default class ReadwisePlugin extends Plugin {
     failedBooks.push(bookId);
     console.log(`Readwise Official plugin: added book id ${bookId} to failed books`);
     this.settings.failedBooks = failedBooks;
-    await this.saveSettings();
+
+    // don't forget to save after!
+    // but don't do that here; this allows batching when removing multiple books.
   }
 
   async addBookToRefresh(bookId: string) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -365,8 +365,6 @@ export default class ReadwisePlugin extends Plugin {
             contentToSave = existingContent + contents;
           }
           await this.fs.write(originalName, contentToSave);
-          await this.removeBooksFromRefresh([bookID]);
-          await this.removeBookFromFailedBooks([bookID]);
         } catch (e) {
           console.log(`Readwise Official plugin: error writing ${processedFileName}:`, e);
           this.notice(`Readwise: error while writing ${processedFileName}: ${e}`, true, 4, true);
@@ -376,6 +374,9 @@ export default class ReadwisePlugin extends Plugin {
           }
           // communicate with readwise?
         }
+
+        await this.removeBooksFromRefresh([bookID]);
+        await this.removeBookFromFailedBooks([bookID]);
       }
       await this.saveSettings();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -498,10 +498,10 @@ export default class ReadwisePlugin extends Plugin {
   }
 
   async addToFailedBooks(bookId: string) {
-    let failedBooks = this.settings.failedBooks || DEFAULT_SETTINGS.failedBooks;
+    let failedBooks = [...(this.settings.failedBooks || DEFAULT_SETTINGS.failedBooks)];
     failedBooks.push(bookId);
     console.log(`Readwise Official plugin: added book id ${bookId} to failed books`);
-    this.settings.booksToRefresh = failedBooks;
+    this.settings.failedBooks = failedBooks;
     await this.saveSettings();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -437,7 +437,7 @@ export default class ReadwisePlugin extends Plugin {
   ) {
     if (!this.settings.token) return;
 
-    let targetBookIds = bookIds
+    let targetBookIds = bookIds || this.settings.failedBooks;
 
     // handle legacy `booksToRefresh` setting; see tsdoc on bookssToRefresh
     if (this.settings.refreshBooks) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -459,7 +459,10 @@ export default class ReadwisePlugin extends Plugin {
     }
 
     if (!targetBookIds.length) {
-      console.log('Readwise Official plugin: no targetBookIds, skipping sync');
+      console.log('Readwise Official plugin: no targetBookIds, checking for new highlights');
+      // no need to hit refresh_book_export;
+      // just check if there's new highlights from the server
+      await this.queueExport();
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,6 +373,7 @@ export default class ReadwisePlugin extends Plugin {
           if (bookID) {
             // handles case where user doesn't have `settings.refreshBooks` enabled
             await this.addToFailedBooks(bookID);
+            return;
           }
           // communicate with readwise?
         }


### PR DESCRIPTION
tl;dr deletion logic changes in #67 had oversight in handling existing deletions which caused unintended re-syncs.

This PR:
- Generally restores the previous method of determining deleted files
- Adds additional comments
- Specifically handles failed books separately of books to refresh (deleted books)

Relevant thread: https://discord.com/channels/886992134505398314/894996177790046228/1283552094296608871

## mental model

HOW IT WORKED BEFORE #67 when a user deleted a file
1. file deleted
2. file path/id removed from `booksIDsMap`
3. book ID added to `booksToRefresh`
4. when syncing, `booksToRefresh` only used when `resync deleted files` enabled
ADDITIONALLY:
- `booksToRefresh` was shared for both deleted and failed book ID collection
- ... which means that failed books would *never* resync if user did not have `resync deleted books` disabled (pre-existing bug)

HOW IT WORKED AFTER #67
1. file deleted
2. file path/id **remains** in `booksIDsMap`
3. book id **not** added to `booksToRefresh`
4. when syncing, (i) `booksToRefresh` **always** used when syncing, (ii) resyncing deleted files determined solely by delta between filesystem & `booksIDsMap`

BUG CAUSLITY:
- (4)(i) was bad logic rework; did not account for legacy book deletion behavior
- `booksToRefresh` list of IDs should only have been used when `resync deleted books` enabled
- additionaly, more work needed to be put into place to handle failed vs deleted books (as the only remaining use of `booksToRefresh` in v2.1 was for failed books)
- another case: if user had bad `path: bookid` in `booksIDsMap` (mismatch between local and db filenames), `refresh_book_export` would be hit every single sync

## repro/testing/validation steps

- sync readwise once
- disable "resync deleted files"
- disable the readwise plugin
- open readwise plugin `data.json`
- pick any book from booksIDsMap
  - copy its ID into `booksToRefresh` array (this replicates pre-#67 deletion behavior)
  - delete the line from `booksIDsMap` (this replicates pre-#67 deletion behavior)
  - save the `data.json` file
  - delete that file from obsidian / your filesystem
- for good measure, reload obsidian workspace (ctrl p > reload app without saving)
- re-enable readwise plugin
- initiate a readwise sync (in plugins, or command palette) if it did not do it upon the plugin being enabled
- after readwise sync completes, verify `data.json`:
  - [ ] the ID you placed in `booksToRefresh` should still be there
  - [ ] the line you deleted from `booksIDsMap` should still NOT be there
  - [ ] the file you deleted from obsidian / your filesystem should still NOT be there
- create a duplicate entry in your `data.json`:
  - edit your `data.json`
  - duplicate one line from `booksIDsMap` but change the **key** (filepath) to something else like `"xxx CHANGED.md": 1234`
  - ensure `resync deleted files` is on
  - re-sync
  - [ ] the non-existant path/file in `booksIDsMap` that you created shouldn't cause `refresh_book_export` to be hit in network calls (because code no longer looks at filesystem delta)

**additional, more sync testing steps below for thoroughness**

> [!WARNING]  
> perform these in listed order

- [ ] confirm clean plugin install syncs notes as expected (this isn't automatic; you must click "initiate sync" or reload the workspace after authenticating)

- **enable `Resync deleted files`**
- delete a synced file
- use command palette to `Readwise Official: Sync your data now`
- [ ] confirm deleted file **is** re-synced

- delete a synced file
- open plugin settings and click `Initiate sync`
- [ ] confirm deleted file **is** re-synced

- open a synced file
- use command palette to `Readwise Official: Delete and reimport this document`
- [ ] confirm file is deleted and **is** re-synced

- delete synced file
- use command palette to `Reload app without saving` (or re-open Obsidian)
- [ ] confirm deleted file **is** re-synced

- **disable `Resync deleted files`**
- delete a synced file
- use command palette to `Readwise Official: Sync your data now`
- [ ] confirm file is **NOT** re-synced

- delete a synced file
- open plugin settings and click `Initiate sync`
- [ ] confirm file is **NOT** re-synced

- delete synced file
- use command palette to `Reload app without saving` (or re-open Obsidian)
- [ ] confirm deleted file **isn't** re-synced

- open a synced file
- use command palette to `Readwise Official: Delete and reimport this document`
- [ ] confirm file **is** re-synced

- delete synced file
- **enable `Resync deleted files`**
- [ ] confirm deleted file **is** re-synced

- and finally, for good measure:
- [ ] ensure adding new highlights continues to work as expected
- [ ] ensure syncing on interval continues to work as expected