### PR TITLE
Update full content of unmodified notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^14.14.2",
+    "crypto-js": "^4.2.0",
     "dotenv": "^10.0.0",
-    "rollup-plugin-dotenv": "^0.3.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1",
+    "rollup-plugin-dotenv": "^0.3.0",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "allowSyntheticDefaultImports": true,
     "lib": [
       "dom",
       "es5",


### PR DESCRIPTION
When adding a new Readwise highlight to an exported book, the plugin appends it to the existing Obsidian note. The best would be if all highlights, both added before and after exporting them to Obsidian, would be rendered in the "Highlights" section. This is non-trivial in case of notes that have been edited in Obsidian so this PR only updates full content of notes that have not been modified. Modified notes will still use the append-only logic.

To support both replacing and append-only logic, this PR requires Readwise to export books as JSON files containing `full_content`, `append_only_content` and `last_hash` fields.

Note: please release this PR with version 3.0.0 as it requires a new export file format.