### PR TITLE
Updating notes content and Reader Documents import

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/crypto-js": "^4.2.2",
     "@types/node": "^14.14.2",
-    "crypto-js": "^4.2.0",
     "dotenv": "^10.0.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1",
     "rollup-plugin-dotenv": "^0.3.0",
+    "ts-md5": "^1.3.1",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "@rollup/plugin-typescript": "^6.0.0",
+    "@types/crypto-js": "^4.2.2",
     "@types/node": "^14.14.2",
+    "crypto-js": "^4.2.0",
     "dotenv": "^10.0.0",
-    "rollup-plugin-dotenv": "^0.3.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1",
+    "rollup-plugin-dotenv": "^0.3.0",
     "tslib": "^2.0.3",
     "typescript": "^4.0.3"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -328,7 +328,7 @@ export default class ReadwisePlugin extends Plugin {
     } else {
       console.log("Readwise Official plugin: bad response in downloadExport: ", response);
       await this.handleSyncError(buttonContext, this.getErrorMessageFromResponse(response));
-      return;
+      throw new Error(`Readwise: error while fetching artifact ${artifactId}`);
     }
 
     this.fs = this.app.vault.adapter;

--- a/src/main.ts
+++ b/src/main.ts
@@ -362,7 +362,7 @@ export default class ReadwisePlugin extends Plugin {
             data = JSON.parse(fileContent);
           }
 
-          bookID = this.encodeReadwiseBookId(data.book_id) || this.encodeReaderDocumentId(data.reader_document_id);
+          bookID = this.encodeReadwiseBookId(data.book_id);
 
           // track the book
           this.settings.booksIDsMap[processedFileName] = bookID;
@@ -413,8 +413,8 @@ export default class ReadwisePlugin extends Plugin {
         }
 
         if (data) {
-          await this.removeBooksFromRefresh([this.encodeReadwiseBookId(data.book_id), this.encodeReaderDocumentId(data.reader_document_id)]);
-          await this.removeBookFromFailedBooks([this.encodeReadwiseBookId(data.book_id), this.encodeReaderDocumentId(data.reader_document_id)]);
+          await this.removeBooksFromRefresh([this.encodeReadwiseBookId(data.book_id)]);
+          await this.removeBookFromFailedBooks([this.encodeReadwiseBookId(data.book_id)]);
         }
       }
       await this.saveSettings();
@@ -511,17 +511,6 @@ export default class ReadwisePlugin extends Plugin {
 
     console.log('Readwise Official plugin: refreshing books', { targetBookIds });
 
-    let requestBookIds: string[] = [];
-    let requestReaderDocumentIds: string[] = [];
-    targetBookIds.map(id => {
-      const readerDocumentId = this.decodeReaderDocumentId(id);
-      if (readerDocumentId) {
-        requestReaderDocumentIds.push(readerDocumentId);
-      } else {
-        requestBookIds.push(id);
-      }
-    });
-
     try {
       const response = await fetch(
         // add books to next archive build from this endpoint
@@ -534,8 +523,7 @@ export default class ReadwisePlugin extends Plugin {
           method: "POST",
           body: JSON.stringify({
             exportTarget: 'obsidian',
-            userBookIds: requestBookIds,
-            readerDocumentIds: requestReaderDocumentIds,
+            userBookIds: targetBookIds,
           })
         }
       );
@@ -570,7 +558,7 @@ export default class ReadwisePlugin extends Plugin {
   async addBookToRefresh(bookId: string) {
     let booksToRefresh = [...this.settings.booksToRefresh];
     booksToRefresh.push(bookId);
-    console.log(`Readwise Official plugin: added book id ${bookId} to failed books`);
+    console.log(`Readwise Official plugin: added book id ${bookId} to refresh list`);
     this.settings.booksToRefresh = booksToRefresh;
     await this.saveSettings();
   }
@@ -816,20 +804,6 @@ export default class ReadwisePlugin extends Plugin {
       return rawBookId.toString()
     }
     return undefined;
-  }
-
-  encodeReaderDocumentId(rawReaderDocumentId?: string) : string | undefined {
-    if (rawReaderDocumentId) {
-      return `readerdocument:${rawReaderDocumentId}`;
-    }
-    return undefined;
-  }
-
-  decodeReaderDocumentId(readerDocumentId?: string) : string | undefined {
-    if (!readerDocumentId || !readerDocumentId.startsWith("readerdocument:")) {
-      return undefined;
-    }
-    return readerDocumentId.replace(/^readerdocument:/, "");
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -199,7 +199,8 @@ export default class ReadwisePlugin extends Plugin {
           console.log("Readwise Official plugin: completed sync");
           // @ts-ignore
           if (this.app.isMobile) {
-            this.notice("If you don't see all of your readwise files reload obsidian app", true,);
+            this.notice("If you don't see all of your Readwise files, please reload the Obsidian app", true,);
+
           }
         } else {
           console.log("Readwise Official plugin: unknown status in getExportStatus: ", data);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
+    "allowSyntheticDefaultImports": true,
     "lib": [
       "dom",
       "es5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "allowSyntheticDefaultImports": true,
     "lib": [
       "dom",
       "es5",


### PR DESCRIPTION
This PR introduces Reader Document import and updating content of notes that have not been modified in Obsidian since they were imported.

## Updating notes content

When adding a new Readwise highlight to an exported book, the plugin currently appends it to the existing Obsidian note. The best would be if all highlights, both added before and after exporting them to Obsidian, would be rendered in the "Highlights" section rather than under "New highlights added..." sections. This is non-trivial in case of notes that have been edited in Obsidian so this PR only updates full content of notes that have not been modified. Modified notes will still use the append-only logic.

To support both replacing and append-only logic, this PR requires Readwise to export books as JSON files containing `full_content`, `append_only_content` and `last_hash` fields. Each file contains also `book_id` and `reader_document_id` fields needed by the Reader Document import feature.

## Reader Document import

With these changes the plugin supports receiving both Readwise Books and Reader Documents in the import file. Both sources can be referenced using the new `book_id` and `reader_document_id` fields in the exported JSON file.

Note: please release this PR with version 3.0.0 as it requires a new export file format.