### PR TITLE
Pass statusID on sync_ack

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -195,7 +195,7 @@ export default class ReadwisePlugin extends Plugin {
           // make sure all artifacts are processed
           await downloadUnprocessedArtifacts(data.artifactIds);
 
-          await this.acknowledgeSyncCompleted(buttonContext);
+          await this.acknowledgeSyncCompleted(buttonContext, statusID);
           await this.handleSyncSuccess(buttonContext, "Synced!", statusID);
           this.notice("Readwise sync completed", true, 1, true);
           console.log("Readwise Official plugin: completed sync");
@@ -456,11 +456,16 @@ export default class ReadwisePlugin extends Plugin {
     });
   }
 
-  async acknowledgeSyncCompleted(buttonContext: ButtonComponent) {
+  async acknowledgeSyncCompleted(buttonContext: ButtonComponent, statusID?: number) {
     let response;
+    // Pass statusID so the server can scope the mark-delivered exactly to the one we
+    // just downloaded, instead of falling back to "all finished+undelivered for config".
+    const url = statusID
+      ? `${baseURL}/api/obsidian/sync_ack?statusID=${statusID}`
+      : `${baseURL}/api/obsidian/sync_ack`;
     try {
       response = await fetch(
-        `${baseURL}/api/obsidian/sync_ack`,
+        url,
         {
           headers: { ...this.getAuthHeaders(), 'Content-Type': 'application/json' },
           method: "POST",


### PR DESCRIPTION
## Summary
- `acknowledgeSyncCompleted` now accepts an optional `statusID` and sends it as `?statusID=X` on the `POST /api/obsidian/sync_ack` request.
- The one caller inside `getExportStatus` already has the status ID in scope and now passes it.
- Backward-compatible: callers that don't pass `statusID` keep working (URL falls back to the old form).

## Why

Companion to [readwiseio/rekindled#8822](https://github.com/readwiseio/rekindled/pull/8822). Without the `statusID`, the server can't tell which export the client just downloaded and has to mark *all* finished+undelivered statuses for the config as delivered — safe in the usual case but imprecise and the source of one cross-install edge case called out in that PR. Sending the ID lets the server scope the mark-delivered exactly.

## Test plan
- [ ] Manual: run a normal sync against a dev backend; confirm the request to `/api/obsidian/sync_ack` includes `?statusID=<id>` and the server's `ExportStatus.delivered_at` is set only on the downloaded row.
- [ ] Manual: simulate a plugin version that doesn't send the param (revert the call site change) — server falls back to the old "mark all finished+undelivered" behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)